### PR TITLE
Relax the filetype detection pattern

### DIFF
--- a/ftdetect/gha.vim
+++ b/ftdetect/gha.vim
@@ -3,4 +3,4 @@
 " Maintainer: yasuhiroki <yasuhiroki.duck@gmail.com>
 " License:    MIT Copyright (c) 2019 yasuhiroki
 
-au BufNewFile,BufReadPost .github/workflows/*.yml setlocal filetype=yaml.gha
+au BufNewFile,BufReadPost */.github/workflows/*.yml setlocal filetype=yaml.gha


### PR DESCRIPTION
The previous pattern doesn't have the flexibility for a prefix of path. For instance `:e .github/workflows/ci.yml` is recognized as `yaml.gha` filetype, but `:e ./.github/workflows/ci.yml` or `:e /full/path/to/repo/.github/workflows/ci.yml` are not. However, these commands edit the same file and it should be recognized as a configuration file for GHA.