### PR TITLE
Allow the `.yaml` extension as a GHA config

### DIFF
--- a/ftdetect/gha.vim
+++ b/ftdetect/gha.vim
@@ -3,4 +3,5 @@
 " Maintainer: yasuhiroki <yasuhiroki.duck@gmail.com>
 " License:    MIT Copyright (c) 2019 yasuhiroki
 
-au BufNewFile,BufReadPost */.github/workflows/*.yml setlocal filetype=yaml.gha
+" https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#about-yaml-syntax-for-workflows
+au BufNewFile,BufReadPost */.github/workflows/*.y{a,}ml setlocal filetype=yaml.gha


### PR DESCRIPTION
`.yaml` is also recognized as configurations of GitHub Actions according to the official document.

> Workflow files use YAML syntax, and must have either a .yml or .yaml file extension.

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#about-yaml-syntax-for-workflows

I didn't know that..., but I guess that almost all users use `.yml` as a file extension of GitHub Actions' configurations. :smile: 