### PR TITLE
Add expression highlights

### DIFF
--- a/autoload/gha.vim
+++ b/autoload/gha.vim
@@ -48,6 +48,21 @@ let s:gha_keywords_step = [
             \ 'with'
             \ ]
 
+let s:gha_keywords_function = [
+            \ 'contains',
+            \ 'startsWith',
+            \ 'endsWith',
+            \ 'format',
+            \ 'join',
+            \ 'toJSON',
+            \ 'fromJSON',
+            \ 'hashFiles',
+            \ 'success',
+            \ 'always',
+            \ 'cancelled',
+            \ 'failure'
+            \ ]
+
 function! gha#GetKeywords()
     return s:gha_keywords
 endfunction
@@ -60,10 +75,15 @@ function! gha#GetKeywordsStep()
     return s:gha_keywords_step
 endfunction
 
+function! gha#GetKeywordsFunction()
+    return s:gha_keywords_function
+endfunction
+
 function! gha#GetKeywordsAll()
     return s:gha_keywords
                 \ + s:gha_keywords_conditional
                 \ + s:gha_keywords_step
+                \ + s:gha_keywords_function
 endfunction
 
 let &cpo = s:save_cpo

--- a/syntax/gha.vim
+++ b/syntax/gha.vim
@@ -10,7 +10,7 @@ let s:gha_keywords_key = '\%(^\|\s\)\@<=\zs\%('.join(gha#GetKeywords(), '\|').'\
 let s:gha_keywords_conditional_key = '\%(^\|\s\)\@<=\zs\%('.join(gha#GetKeywordsConditional(), '\|').'\)\ze\%(\s*:\|$\)'
 let s:gha_keywords_step_key = '\%([0-9A-Za-z_-]\)\@<!\%('.join(gha#GetKeywordsStep(), '\|').'\)\ze\%(\s*:\|$\)'
 
-syn region GhaDollarSyntax matchgroup=PreProc start="${{" end="}}" containedin=yamlPlainScalar keepend
+syn region GhaDollarSyntax matchgroup=PreProc start="${{" end="}}" containedin=yamlPlainScalar
 
 exe 'syn match GhaKeywords /'.s:gha_keywords_key.'/ contained nextgroup=yamlKeyValueDelimiter containedin=yamlBlockMappingKey'
 exe 'syn match GhaKeywordsConditional /'.s:gha_keywords_conditional_key.'/ contained nextgroup=yamlKeyValueDelimiter containedin=yamlBlockMappingKey'

--- a/syntax/gha.vim
+++ b/syntax/gha.vim
@@ -31,16 +31,16 @@ syn region GhaString start=/'/ skip=/''/ end=/'/ contained containedin=GhaDollar
 syn match GhaOperator /\%(||\|&&\|==\|!=\|>=\|>\|<=\|<\|!\)/ contained containedin=GhaDollarSyntax
 exe 'syn region GhaFunction matchgroup=GhaKeywordsFunction start=/\<\%(' . join(gha#GetKeywordsFunction(), '\|') . '\)\ze(/ end=/\ze)/ contained containedin=GhaDollarSyntax contains=@GhaLiterals,GhaOperator,GhaKeywordsDollarSyntax'
 
-hi link GhaKeywords Keyword
-hi link GhaKeywordsConditional Conditional
-hi link GhaKeywordsStep Define
-hi link GhaKeywordsParameter Keyword
-hi link GhaKeywordsDollarSyntax Keyword
-hi link GhaNull Keyword
-hi link GhaBoolean Boolean
-hi link GhaNumber Number
-hi link GhaString String
-hi link GhaOperator Operator
-hi link GhaKeywordsFunction Function
+hi def link GhaKeywords Keyword
+hi def link GhaKeywordsConditional Conditional
+hi def link GhaKeywordsStep Define
+hi def link GhaKeywordsParameter Keyword
+hi def link GhaKeywordsDollarSyntax Keyword
+hi def link GhaNull Keyword
+hi def link GhaBoolean Boolean
+hi def link GhaNumber Number
+hi def link GhaString String
+hi def link GhaOperator Operator
+hi def link GhaKeywordsFunction Function
 
 let &cpo = s:save_cpo

--- a/syntax/gha.vim
+++ b/syntax/gha.vim
@@ -19,10 +19,28 @@ exe 'syn match GhaKeywordsStep /'.s:gha_keywords_step_key.'/ contained nextgroup
 " https://docs.github.com/en/actions/learn-github-actions/contexts
 syn match GhaKeywordsDollarSyntax /\%(\.\)\@<!\<\%(github\|env\|job\|steps\|runner\|secrets\|strategy\|matrix\|inputs\)\>/ contained containedin=GhaDollarSyntax
 
+" https://docs.github.com/en/actions/learn-github-actions/expressions
+syn cluster GhaLiterals contains=GhaNull,GhaBoolean,GhaNumber,GhaString
+syn keyword GhaNull null contained containedin=GhaDollarSyntax
+syn keyword GhaBoolean true false contained containedin=GhaDollarSyntax
+" NOTE: The "Number" definition in dollar syntax is equal to JSON's one, so
+" this syntax pattern is imported from "$VIMRUNTIME/syntax/json.vim" with
+" small fixes.
+syn match GhaNumber /\<-\=\<\%(0\|[1-9]\d*\)\%(\.\d\+\)\=\%([eE][-+]\=\d\+\)\=\>/ contained containedin=GhaDollarSyntax
+syn region GhaString start=/'/ skip=/''/ end=/'/ contained containedin=GhaDollarSyntax
+syn match GhaOperator /\%(||\|&&\|==\|!=\|>=\|>\|<=\|<\|!\)/ contained containedin=GhaDollarSyntax
+exe 'syn region GhaFunction matchgroup=GhaKeywordsFunction start=/\<\%(' . join(gha#GetKeywordsFunction(), '\|') . '\)\ze(/ end=/\ze)/ contained containedin=GhaDollarSyntax contains=@GhaLiterals,GhaOperator,GhaKeywordsDollarSyntax'
+
 hi link GhaKeywords Keyword
 hi link GhaKeywordsConditional Conditional
 hi link GhaKeywordsStep Define
 hi link GhaKeywordsParameter Keyword
 hi link GhaKeywordsDollarSyntax Keyword
+hi link GhaNull Keyword
+hi link GhaBoolean Boolean
+hi link GhaNumber Number
+hi link GhaString String
+hi link GhaOperator Operator
+hi link GhaKeywordsFunction Function
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
This patch implements expressions(https://docs.github.com/en/actions/learn-github-actions/expressions) highlighting in dollar syntax and fixes small stuffs.

Before:

![screen_shot_2022-03-07T12:34:51+0900](https://user-images.githubusercontent.com/12132068/156963879-1a9779e0-5735-4348-b818-1e61c2529476.png)

After:

![screen_shot_2022-03-07T12:33:21+0900](https://user-images.githubusercontent.com/12132068/156963930-c6023ac5-150b-49ca-b5ed-4f9d58f80d5f.png)