### PR TITLE
Support more context variables and keywords, support action.yml files

### DIFF
--- a/autoload/gha.vim
+++ b/autoload/gha.vim
@@ -6,12 +6,17 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:gha_keywords = [
+let s:gha_workflow_keywords = [
             \ 'cmd',
+            \ 'uses',
+            \ 'shell',
+            \ 'concurrency',
             \ 'container',
-            \ 'create',
-            \ 'docker',
+            \ 'continue-on-error',
+            \ 'credentials',
+            \ 'defaults',
             \ 'env',
+            \ 'environment',
             \ 'fail-fast',
             \ 'image',
             \ 'jobs',
@@ -22,14 +27,44 @@ let s:gha_keywords = [
             \ 'on',
             \ 'options',
             \ 'paths',
+            \ 'permissions',
             \ 'ports',
+            \ 'run',
+            \ 'run-name',
             \ 'runs-on',
             \ 'schedule',
+            \ 'secrets',
             \ 'services',
             \ 'steps',
             \ 'strategy',
+            \ 'timeout-minutes',
             \ 'types',
-            \ 'volumes'
+            \ 'volumes',
+            \ 'with',
+            \ 'working-directory',
+            \ ]
+
+let s:gha_action_keywords = [
+            \ 'author',
+            \ 'branding',
+            \ 'color',
+            \ 'default',
+            \ 'deprecationMessage',
+            \ 'description',
+            \ 'icon',
+            \ 'inputs',
+            \ 'main',
+            \ 'name',
+            \ 'outputs',
+            \ 'post',
+            \ 'post-if',
+            \ 'pre',
+            \ 'pre-if',
+            \ 'required',
+            \ 'runs',
+            \ 'steps',
+            \ 'using',
+            \ 'value',
             \ ]
 
 let s:gha_keywords_conditional = [
@@ -39,13 +74,17 @@ let s:gha_keywords_conditional = [
 let s:gha_keywords_step = [
             \ 'args',
             \ 'continue-on-error',
+            \ 'defaults',
             \ 'entrypoint',
             \ 'env',
             \ 'id',
+            \ 'name',
             \ 'run',
+            \ 'shell',
             \ 'timeout-minutes',
             \ 'uses',
-            \ 'with'
+            \ 'with',
+            \ 'working-directory',
             \ ]
 
 let s:gha_keywords_function = [
@@ -64,7 +103,7 @@ let s:gha_keywords_function = [
             \ ]
 
 function! gha#GetKeywords()
-    return s:gha_keywords
+    return s:gha_workflow_keywords + s:gha_action_keywords
 endfunction
 
 function! gha#GetKeywordsConditional()
@@ -80,7 +119,8 @@ function! gha#GetKeywordsFunction()
 endfunction
 
 function! gha#GetKeywordsAll()
-    return s:gha_keywords
+    return s:gha_workflow_keywords
+                \ + s:gha_action_keywords
                 \ + s:gha_keywords_conditional
                 \ + s:gha_keywords_step
                 \ + s:gha_keywords_function

--- a/ftdetect/gha.vim
+++ b/ftdetect/gha.vim
@@ -4,4 +4,5 @@
 " License:    MIT Copyright (c) 2019 yasuhiroki
 
 " https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#about-yaml-syntax-for-workflows
-au BufNewFile,BufReadPost */.github/workflows/*.y{a,}ml setlocal filetype=yaml.gha
+" https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#about-yaml-syntax-for-github-actions
+au BufNewFile,BufReadPost */.github/workflows/*.y{a,}ml,action.y{a,}ml setlocal filetype=yaml.gha

--- a/syntax/gha.vim
+++ b/syntax/gha.vim
@@ -17,7 +17,7 @@ exe 'syn match GhaKeywordsConditional /'.s:gha_keywords_conditional_key.'/ conta
 exe 'syn match GhaKeywordsStep /'.s:gha_keywords_step_key.'/ contained nextgroup=yamlKeyValueDelimiter containedin=yamlBlockMappingKey'
 
 " https://docs.github.com/en/actions/learn-github-actions/contexts
-syn match GhaKeywordsDollarSyntax /\%(\.\)\@<!\<\%(github\|env\|job\|steps\|runner\|secrets\|strategy\|matrix\|inputs\)\>/ contained containedin=GhaDollarSyntax
+syn match GhaKeywordsDollarSyntax /\%(\.\)\@<!\<\%(github\|env\|vars\|jobs\?\|steps\|runner\|secrets\|strategy\|matrix\|needs\|inputs\)\.\@=/ contained containedin=GhaDollarSyntax
 
 " https://docs.github.com/en/actions/learn-github-actions/expressions
 syn cluster GhaLiterals contains=GhaNull,GhaBoolean,GhaNumber,GhaString

--- a/syntax/gha.vim
+++ b/syntax/gha.vim
@@ -10,7 +10,8 @@ let s:gha_keywords_key = '\%(^\|\s\)\@<=\zs\%('.join(gha#GetKeywords(), '\|').'\
 let s:gha_keywords_conditional_key = '\%(^\|\s\)\@<=\zs\%('.join(gha#GetKeywordsConditional(), '\|').'\)\ze\%(\s*:\|$\)'
 let s:gha_keywords_step_key = '\%([0-9A-Za-z_-]\)\@<!\%>6c\%('.join(gha#GetKeywordsStep(), '\|').'\)\ze\%(\s*:\|$\)'
 
-syn region GhaDollarSyntax matchgroup=PreProc start="${{" end="}}" containedin=yamlPlainScalar
+syn region GhaDollarSyntax matchgroup=PreProc start="${{" end="}}" containedin=yamlPlainScalar,yamlFlowString,yamlBlockString
+syn region GhaDollarSyntax start=/\%(^\s*if\s*:\s*\)\@<=[^ $]/ end=/$/ keepend oneline containedin=yamlPlainScalar
 
 exe 'syn match GhaKeywords /'.s:gha_keywords_key.'/ contained nextgroup=yamlKeyValueDelimiter containedin=yamlBlockMappingKey'
 exe 'syn match GhaKeywordsConditional /'.s:gha_keywords_conditional_key.'/ contained nextgroup=yamlKeyValueDelimiter containedin=yamlBlockMappingKey'

--- a/syntax/gha.vim
+++ b/syntax/gha.vim
@@ -8,13 +8,14 @@ set cpo&vim
 
 let s:gha_keywords_key = '\%(^\|\s\)\@<=\zs\%('.join(gha#GetKeywords(), '\|').'\)\ze\%(\s*:\|$\)'
 let s:gha_keywords_conditional_key = '\%(^\|\s\)\@<=\zs\%('.join(gha#GetKeywordsConditional(), '\|').'\)\ze\%(\s*:\|$\)'
-let s:gha_keywords_step_key = '\%([0-9A-Za-z_-]\)\@<!\%('.join(gha#GetKeywordsStep(), '\|').'\)\ze\%(\s*:\|$\)'
+let s:gha_keywords_step_key = '\%([0-9A-Za-z_-]\)\@<!\%>6c\%('.join(gha#GetKeywordsStep(), '\|').'\)\ze\%(\s*:\|$\)'
 
 syn region GhaDollarSyntax matchgroup=PreProc start="${{" end="}}" containedin=yamlPlainScalar
 
 exe 'syn match GhaKeywords /'.s:gha_keywords_key.'/ contained nextgroup=yamlKeyValueDelimiter containedin=yamlBlockMappingKey'
 exe 'syn match GhaKeywordsConditional /'.s:gha_keywords_conditional_key.'/ contained nextgroup=yamlKeyValueDelimiter containedin=yamlBlockMappingKey'
 exe 'syn match GhaKeywordsStep /'.s:gha_keywords_step_key.'/ contained nextgroup=yamlKeyValueDelimiter containedin=yamlBlockMappingKey'
+unlet s:gha_keywords_key s:gha_keywords_conditional_key s:gha_keywords_step_key
 
 " https://docs.github.com/en/actions/learn-github-actions/contexts
 syn match GhaKeywordsDollarSyntax /\%(\.\)\@<!\<\%(github\|env\|vars\|jobs\?\|steps\|runner\|secrets\|strategy\|matrix\|needs\|inputs\)\.\@=/ contained containedin=GhaDollarSyntax
@@ -44,3 +45,4 @@ hi def link GhaOperator Operator
 hi def link GhaKeywordsFunction Function
 
 let &cpo = s:save_cpo
+unlet s:save_cpo


### PR DESCRIPTION
This PR updates the syntax file to support more context variables.
It improves the syntax highlighting to highlight dollar syntax in YAML flow strings, block strings, and bare conditional expressions.
Note that the highlight group `yamlBlockString` was introduced very recently by my PR (https://github.com/vim/vim/pull/14354), but I think this will be soon distributed.
Also, it supports action.yml and action.yaml files for local actions and action developers.
